### PR TITLE
fixes #2

### DIFF
--- a/EasyBullet.rbxmx
+++ b/EasyBullet.rbxmx
@@ -6,9 +6,10 @@
 
 -- COPYRIGHT 2023 Zach Curtis
 -- Distrubted under the MIT License
--- VERSION 0.2.4
+-- VERSION 0.3.0
 
 local RunService = game:GetService("RunService")
+local HttpService = game:GetService("HttpService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Players = game:GetService("Players")
 
@@ -19,11 +20,18 @@ export type ShouldFireCallback = (shooter: Player?, barrelPosition: Vector3, vel
 
 type EasyBulletProps = {
 	EasyBulletSettings: Bullet.EasyBulletSettings,
+
 	BulletHit: Signal.Signal&lt;Player?, RaycastResult, Bullet.BulletData>,
 	BulletHitHumanoid: Signal.Signal&lt;Player?, RaycastResult, Humanoid, Bullet.BulletData>,
 	BulletUpdated: Signal.Signal&lt;Vector3, Vector3, Bullet.BulletData>,
-	Bullets: {[number]: Bullet.Bullet},
+
+	Bullets: {[string]: Bullet.Bullet},
+	HitConnections: {[string]: Signal.SignalConnection},
+	BelowFallenPartsConnections: {[string]: Signal.SignalConnection},
+
 	FiredRemote: RemoteEvent?,
+	CanceledRemote: RemoteEvent?,
+
 	CustomCastCallback: Bullet.CastCallback?, --(Player?, Vector3, Vector3, number, Bullet.BulletData) -> ()?,
 	ShouldFireCallback: ShouldFireCallback?
 }
@@ -67,6 +75,7 @@ local function overrideDefaults(newEasyBulletSettings: Bullet.EasyBulletSettings
 		if key == "BulletData" then
 			for dataKey, _ in pairs(value) do
 				assert(dataKey ~= "HitVelocity", `Cannot use key "HitVelocity" in provided BulletData table. "HitVelocity" is a reserved key string used by EasyBullet`)
+				assert(dataKey ~= "BulletId", `Cannot use key "BulletId" in provided BulletData table. "BulletId" is a reserved key string used by EasyBullet`)
 			end
 		end
 
@@ -96,9 +105,13 @@ function EasyBullet.new(easyBulletSettings: Bullet.EasyBulletSettings?)
 	self.BulletHitHumanoid = Signal.new()
 	self.BulletUpdated = Signal.new()
 
-	self.Bullets = {} :: {[number]: Bullet.Bullet}
+	self.Bullets = {} :: {[string]: Bullet.Bullet}
+	self.HitConnections = {} :: {[string]: Signal.SignalConnection}
+	self.BelowFallenPartsConnections = {} :: {[string]: Signal.SignalConnection}
 
 	self.FiredRemote = nil
+	self.CanceledRemote = nil
+
 	self.CustomCastCallback = nil
 	self.ShouldFireCallback = nil
 
@@ -115,17 +128,22 @@ function EasyBullet:FireBullet(barrelPosition: Vector3, bulletVelocity: Vector3,
 	
 	assert(typeof(barrelPosition) == "Vector3", "The first parameter to EasyBullet:FireBullet must be a Vector3")
 	assert(typeof(bulletVelocity) == "Vector3", "The second parameter to EasyBullet:FireBullet must be a Vector3")
-	
-	easyBulletSettings = optionalTableMerge(easyBulletSettings or {} :: Bullet.EasyBulletSettings, self.EasyBulletSettings)
+
+	local thisEasyBulletSettings = optionalTableMerge(easyBulletSettings or {} :: Bullet.EasyBulletSettings, self.EasyBulletSettings)
+
+	-- Create a UUID linked to this bullet so it can be referenced over the network later
+	local bulletId = HttpService:GenerateGUID()
+
+	thisEasyBulletSettings.BulletData.BulletId = bulletId
 
 	-- Server; only used for non player bullets.
 	if RunService:IsServer() then
 		for _, v in ipairs(Players:GetPlayers()) do
 			local thisPing = v:GetNetworkPing()
-			self.FiredRemote:FireClient(v, nil, barrelPosition, bulletVelocity, thisPing, easyBulletSettings)
+			self.FiredRemote:FireClient(v, nil, barrelPosition, bulletVelocity, thisPing, thisEasyBulletSettings)
 		end
 
-		self:_fireBullet(nil, barrelPosition, bulletVelocity, 0, easyBulletSettings)
+		self:_fireBullet(nil, barrelPosition, bulletVelocity, 0, thisEasyBulletSettings)
 	
 	-- Client
 	elseif RunService:IsClient() then
@@ -134,9 +152,9 @@ function EasyBullet:FireBullet(barrelPosition: Vector3, bulletVelocity: Vector3,
 			return
 		end
 
-		self.FiredRemote:FireServer(barrelPosition, bulletVelocity, easyBulletSettings)
+		self.FiredRemote:FireServer(barrelPosition, bulletVelocity, thisEasyBulletSettings)
 
-		self:_fireBullet(Players.LocalPlayer, barrelPosition, bulletVelocity, 0, easyBulletSettings)
+		self:_fireBullet(Players.LocalPlayer, barrelPosition, bulletVelocity, 0, thisEasyBulletSettings)
 	end
 end
 
@@ -152,18 +170,42 @@ function EasyBullet:BindShouldFire(callback: ShouldFireCallback)
 	self.ShouldFireCallback = callback
 end
 
-function EasyBullet:_destroyBullet(bullet: Bullet.Bullet)
-	for i, v: Bullet.Bullet in ipairs(self.Bullets) do
-		if v == bullet then
-			table.remove(self.Bullets, i)
-			break
-		end
+function EasyBullet:_destroyBullet(bulletToDestroy: Bullet.Bullet | string)
+	local bulletId: string
+	local bullet: Bullet.Bullet
+
+	if type(bulletToDestroy) == "string" then
+		bulletId = bulletToDestroy
+		bullet = self.Bullets[bulletId]
+	else
+		local tryBulletId = bulletToDestroy.EasyBulletSettings.BulletData.BulletId
+		assert(type(tryBulletId) == "string", "Cannot destroy bullet as EasyBullet did not assign a BulletId for this bullet.")
+		
+		bulletId = tryBulletId
+		bullet = bulletToDestroy
+	end
+
+	self.Bullets[bulletId] = nil
+
+	if self.HitConnections[bulletId] ~= nil then
+		self.HitConnections[bulletId].Disconnect()
+
+		self.HitConnections[bulletId] = nil
+	end
+
+	if self.BelowFallenPartsConnections[bulletId] ~= nil then
+		self.BelowFallenPartsConnections[bulletId].Disconnect()
+
+		self.BelowFallenPartsConnections[bulletId] = nil
 	end
 
 	bullet:Destroy()
 end
 
 function EasyBullet._fireBullet(self: EasyBullet, shootingPlayer: Player?, barrelPos: Vector3, velocity: Vector3, ping: number, easyBulletSettings: Bullet.EasyBulletSettings)
+
+	local bulletId = easyBulletSettings.BulletData.BulletId
+	assert(type(bulletId) == "string", "EasyBullet did not assign a BulletId for this bullet.")
 	
 	-- Let users filter bullets being fired
 	if self.ShouldFireCallback then
@@ -172,60 +214,50 @@ function EasyBullet._fireBullet(self: EasyBullet, shootingPlayer: Player?, barre
 		assert(type(shouldFire) == "boolean", `The callback bound by EasyBullet:BindShouldFire must return a boolean, shouldFireCallback returned: {typeof(shouldFire)}`)
 		
 		if shouldFire == false then
+			
+			assert(self.CanceledRemote ~= nil, "self.CanceledRemote does not reference ReplicatedStorage.EasyBulletCanceled")
+
+			if RunService:IsServer() then
+				self.CanceledRemote:FireAllClients(bulletId)
+			elseif RunService:IsClient() then
+				self.CanceledRemote:FireServer(bulletId)
+			end
+			
 			return
 		end
 	end
 
 	local bullet = Bullet.new(shootingPlayer, barrelPos, velocity, easyBulletSettings)
-		
-		local hitConnection, belowFallenParts
 
-		hitConnection = bullet.BulletHit:Connect(function(rayResult: RaycastResult, hitHumanoid: Humanoid | boolean)
-			self.BulletHit:Fire(shootingPlayer, rayResult, easyBulletSettings.BulletData)
+	self.HitConnections[bulletId] = bullet.BulletHit:Connect(function(rayResult: RaycastResult, hitHumanoid: Humanoid | boolean)
+		self.BulletHit:Fire(shootingPlayer, rayResult, easyBulletSettings.BulletData)
 
-			if type(hitHumanoid) ~= "boolean" then
-				self.BulletHitHumanoid:Fire(shootingPlayer, rayResult, hitHumanoid, easyBulletSettings.BulletData)
-			end
+		if type(hitHumanoid) ~= "boolean" then
+			self.BulletHitHumanoid:Fire(shootingPlayer, rayResult, hitHumanoid, easyBulletSettings.BulletData)
+		end
 
-			hitConnection:Disconnect()
-			belowFallenParts:Disconnect()
+		self:_destroyBullet(bullet)
+	end)
 
-			self:_destroyBullet(bullet)
-		end)
+	self.BelowFallenPartsConnections[bulletId] = bullet.BelowFallenParts:Connect(function()
+		self:_destroyBullet(bullet)
+	end)
 
-		belowFallenParts = bullet.BelowFallenParts:Connect(function()
-			hitConnection:Disconnect()
-			belowFallenParts:Disconnect()
+	bullet:Start(ping)
 
-			self:_destroyBullet(bullet)
-		end)
-
-		bullet:Start(ping)
-
-		table.insert(self.Bullets, bullet)
+	self.Bullets[bulletId] = bullet
 end
 
 function EasyBullet:_bindEvents()
 	-- Server
 	if RunService:IsServer() then
-		local firedRemote = ReplicatedStorage:FindFirstChild("EasyBulletFired") :: RemoteEvent
 
-		if not firedRemote then
-			self.FiredRemote = Instance.new("RemoteEvent")
-
-			if self.FiredRemote then
-				self.FiredRemote.Name = "EasyBulletFired"
-				self.FiredRemote.Parent = ReplicatedStorage
-			end
-		else
-			self.FiredRemote = firedRemote
-		end
-
-		if not self.FiredRemote then
-			return
-		end
+		-- Look for existing EasyBulletFired RemoteEvent. Create one if it does not exist.
+		self.FiredRemote = self:_findOrCreateRemote("EasyBulletFired")
+		assert(self.FiredRemote ~= nil, "self.FiredRemote cannot be nil.")
 
 		self.FiredRemote.OnServerEvent:Connect(function(player: Player, barrelPos: Vector3, velocity: Vector3, easyBulletSettings: Bullet.EasyBulletSettings)
+			-- Sanity check params
 			if typeof(barrelPos) ~= "Vector3" then
 				warn(`{player.Name} passed a malformed barrelPosition type to EasyBulletFired RemoteEvent\nExpected: Vector3, got: {typeof(barrelPos)}`)
 				return
@@ -236,8 +268,10 @@ function EasyBullet:_bindEvents()
 				return
 			end
 
+			-- Use shooter's ping to account for network desync.
 			local ping = player:GetNetworkPing()
 
+			-- Replicate shot to all other clients
 			for _, v in ipairs(Players:GetPlayers()) do
 				if v == player then continue end
 				
@@ -246,31 +280,73 @@ function EasyBullet:_bindEvents()
 				self.FiredRemote:FireClient(v, player, barrelPos, velocity, ping + thisPing, easyBulletSettings)
 			end
 
+			-- Start handling the shot on the server
 			self:_fireBullet(player, barrelPos, velocity, ping, easyBulletSettings)
 		end)
 
+		-- Look for existing EasyBulletCanceled RemoteEvent. Create one if it does not exist.
+		self.CanceledRemote = self:_findOrCreateRemote("EasyBulletCanceled")
+		assert(self.CanceledRemote ~= nil, "self.CanceledRemote cannot be nil.")
+
+		-- Handle the CanceledRemote
+		self.CanceledRemote.OnServerEvent:Connect(function(cancelingPlayer: Player, bulletId: string)
+			local bullet = self.Bullets[bulletId]
+
+			if not bullet then
+				warn(`No Bullet with a BulletId of {bulletId} was found`)
+				return
+			end
+
+			if not bullet.Shooter then
+				warn(`{cancelingPlayer.Name} cannot cancel a bullet owned by the server. BulletId: {bulletId}`)
+				return
+			end
+
+			if bullet.Shooter and bullet.Shooter ~= cancelingPlayer then
+				warn(`{cancelingPlayer.Name} cannot cancel a bullet owned by {bullet.Shooter.Name}. BulletId: {bulletId}`)
+				return
+			end
+
+			self:_destroyBullet(bulletId)
+		end)
+
+
 	-- Client
 	elseif RunService:IsClient() then
+		-- Make references to our remotes
 		self.FiredRemote = ReplicatedStorage:WaitForChild("EasyBulletFired") :: RemoteEvent
+		self.CanceledRemote = ReplicatedStorage:WaitForChild(("EasyBulletCanceled")) :: RemoteEvent
 
 		if not self.FiredRemote then
 			warn("No RemoteEvent named 'EasyBulletFired' found as a child of ReplicatedStorage")
 			return
 		end
-		
 
+		if not self.CanceledRemote then
+			warn("No RemoteEvent named 'EasyBulletCanceled' found as a child of ReplicatedStorage")
+			return
+		end
+		
+		-- Handle the FiredRemote
 		self.FiredRemote.OnClientEvent:Connect(function(shootingPlayer: Player, barrelPos: Vector3, velocity: Vector3, accumulatedPing: number, easyBulletSettings: Bullet.EasyBulletSettings)
+			-- The server shouldn't ever replicate back a shot this client fired, but check that just to be safe.
 			if shootingPlayer == Players.LocalPlayer then
 				return
 			end
 			
 			self:_fireBullet(shootingPlayer, barrelPos, velocity, accumulatedPing, easyBulletSettings)
 		end)
+
+		-- Handle the CanceledRemote
+		self.CanceledRemote.OnClientEvent:Connect(function(bulletId: string)
+			self:_destroyBullet(bulletId)
+		end)
+
 	end
 
 	-- Both
 	RunService.Heartbeat:Connect(function()
-		for _, bullet: Bullet.Bullet in ipairs(self.Bullets) do
+		for _, bullet: Bullet.Bullet in pairs(self.Bullets) do
 			local lastPosition, currentPosition = bullet:Update(self.CustomCastCallback)
 
 			-- Update returns nil when bullet drops below workspace.FallenPartsDestroyHeight
@@ -279,6 +355,22 @@ function EasyBullet:_bindEvents()
 			end
 		end
 	end)
+end
+
+function EasyBullet:_findOrCreateRemote(remoteName: string): RemoteEvent
+	local foundRemote = ReplicatedStorage:FindFirstChild(remoteName)
+
+	if foundRemote == nil then
+		foundRemote = Instance.new("RemoteEvent")
+		foundRemote.Name = remoteName
+		foundRemote.Parent = ReplicatedStorage
+
+		return foundRemote
+	elseif foundRemote:IsA("RemoteEvent") then
+		return foundRemote
+	else
+		error(`Instance named {remoteName} is of type {foundRemote.ClassName}, not RemoteEvent`)
+	end
 end
 
 return EasyBullet</string>
@@ -297,7 +389,7 @@ local KinematicEquations = require(script:WaitForChild("KinematicEquations"))
 local BulletDraw = require(script:WaitForChild("BulletDraw"))
 local Signal = require(script.Parent:WaitForChild("Signal"))
 
-type BulletDataKey = "HitVelocity"
+type BulletDataKey = "HitVelocity" | "BulletId"
 
 export type BulletData = {[BulletDataKey | string]: unknown}
 
@@ -381,7 +473,7 @@ function Bullet.new(shootingPlayer: Player?, barrelPosition: Vector3, velocity: 
     return self
 end
 
-function Bullet:Start(ping: number?)
+function Bullet.Start(self: Bullet, ping: number?)
     self.StartTime = os.clock()
 
     if ping then 
@@ -721,7 +813,7 @@ return KinematicEquations</string>
 -- closure scoping reimplement of https://github.com/LPGhatguy/lemur/blob/master/lib/Signal.lua
 -- does not defer events
 
-type SignalConnection = {
+export type SignalConnection = {
 	Disconnect: (self: SignalConnection) -> ()
 }
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ rojo serve
 
 To install using wally, add to your wally.toml dependencies:
 ```toml
-EasyBullet = "zachcurtis/easybullet@0.3.0"
+EasyBullet = "zachcurtis/easybullet@0.3.1"
 ```
 Then run:
 ```bash
@@ -63,7 +63,7 @@ export type EasyBulletSettings = {
     FilterList: {[number]: Instance}?, -- An array of instances assigned to RayParams.FilterDescendantsInstances
     FilterType: Enum.RaycastFilterType?, -- The RaycastFilterType, either Include or Exclude
     BulletPartProps: {[string]: unknown}?, -- A dictionary of properties matching the properties of BasePart to override the bullet part rendering. Cannot include keys "CFrame", "Size", or "Color"
-    BulletData: {[string]: unknown}? -- A dictionary of any data you wish to associate with this bullet. HitVelocity is a reserved key for this table, and is set by EasyBullet before passing the BulletData table to the BulletHit, BulletHitHumanoid, and BulletUpdated events. Useful for variations such as displaying a different hit effect for a sniper, or altering the damage dependent on the gun type.
+    BulletData: {[string]: unknown}? -- A dictionary of any data you wish to associate with this bullet. HitVelocity and BulletId are reserved keys for this table, and are set by EasyBullet before passing the BulletData table to the BulletHit, BulletHitHumanoid, and BulletUpdated events. Useful for variations such as displaying a different hit effect for a sniper, or altering the damage dependent on the gun type.
 }
 ```
 #### Default EasyBulletSettings

--- a/src/Bullet/init.lua
+++ b/src/Bullet/init.lua
@@ -9,7 +9,7 @@ local KinematicEquations = require(script:WaitForChild("KinematicEquations"))
 local BulletDraw = require(script:WaitForChild("BulletDraw"))
 local Signal = require(script.Parent:WaitForChild("Signal"))
 
-type BulletDataKey = "HitVelocity"
+type BulletDataKey = "HitVelocity" | "BulletId"
 
 export type BulletData = {[BulletDataKey | string]: unknown}
 
@@ -93,7 +93,7 @@ function Bullet.new(shootingPlayer: Player?, barrelPosition: Vector3, velocity: 
     return self
 end
 
-function Bullet:Start(ping: number?)
+function Bullet.Start(self: Bullet, ping: number?)
     self.StartTime = os.clock()
 
     if ping then 

--- a/src/Signal.lua
+++ b/src/Signal.lua
@@ -3,7 +3,7 @@
 -- closure scoping reimplement of https://github.com/LPGhatguy/lemur/blob/master/lib/Signal.lua
 -- does not defer events
 
-type SignalConnection = {
+export type SignalConnection = {
 	Disconnect: (self: SignalConnection) -> ()
 }
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -2,9 +2,10 @@
 
 -- COPYRIGHT 2023 Zach Curtis
 -- Distrubted under the MIT License
--- VERSION 0.3.0
+-- VERSION 0.3.1
 
 local RunService = game:GetService("RunService")
+local HttpService = game:GetService("HttpService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Players = game:GetService("Players")
 
@@ -15,11 +16,18 @@ export type ShouldFireCallback = (shooter: Player?, barrelPosition: Vector3, vel
 
 type EasyBulletProps = {
 	EasyBulletSettings: Bullet.EasyBulletSettings,
+
 	BulletHit: Signal.Signal<Player?, RaycastResult, Bullet.BulletData>,
 	BulletHitHumanoid: Signal.Signal<Player?, RaycastResult, Humanoid, Bullet.BulletData>,
 	BulletUpdated: Signal.Signal<Vector3, Vector3, Bullet.BulletData>,
-	Bullets: {[number]: Bullet.Bullet},
+
+	Bullets: {[string]: Bullet.Bullet},
+	HitConnections: {[string]: Signal.SignalConnection},
+	BelowFallenPartsConnections: {[string]: Signal.SignalConnection},
+
 	FiredRemote: RemoteEvent?,
+	CanceledRemote: RemoteEvent?,
+
 	CustomCastCallback: Bullet.CastCallback?, --(Player?, Vector3, Vector3, number, Bullet.BulletData) -> ()?,
 	ShouldFireCallback: ShouldFireCallback?
 }
@@ -63,6 +71,7 @@ local function overrideDefaults(newEasyBulletSettings: Bullet.EasyBulletSettings
 		if key == "BulletData" then
 			for dataKey, _ in pairs(value) do
 				assert(dataKey ~= "HitVelocity", `Cannot use key "HitVelocity" in provided BulletData table. "HitVelocity" is a reserved key string used by EasyBullet`)
+				assert(dataKey ~= "BulletId", `Cannot use key "BulletId" in provided BulletData table. "BulletId" is a reserved key string used by EasyBullet`)
 			end
 		end
 
@@ -92,9 +101,13 @@ function EasyBullet.new(easyBulletSettings: Bullet.EasyBulletSettings?)
 	self.BulletHitHumanoid = Signal.new()
 	self.BulletUpdated = Signal.new()
 
-	self.Bullets = {} :: {[number]: Bullet.Bullet}
+	self.Bullets = {} :: {[string]: Bullet.Bullet}
+	self.HitConnections = {} :: {[string]: Signal.SignalConnection}
+	self.BelowFallenPartsConnections = {} :: {[string]: Signal.SignalConnection}
 
 	self.FiredRemote = nil
+	self.CanceledRemote = nil
+
 	self.CustomCastCallback = nil
 	self.ShouldFireCallback = nil
 
@@ -111,17 +124,22 @@ function EasyBullet:FireBullet(barrelPosition: Vector3, bulletVelocity: Vector3,
 	
 	assert(typeof(barrelPosition) == "Vector3", "The first parameter to EasyBullet:FireBullet must be a Vector3")
 	assert(typeof(bulletVelocity) == "Vector3", "The second parameter to EasyBullet:FireBullet must be a Vector3")
-	
-	easyBulletSettings = optionalTableMerge(easyBulletSettings or {} :: Bullet.EasyBulletSettings, self.EasyBulletSettings)
+
+	local thisEasyBulletSettings = optionalTableMerge(easyBulletSettings or {} :: Bullet.EasyBulletSettings, self.EasyBulletSettings)
+
+	-- Create a UUID linked to this bullet so it can be referenced over the network later
+	local bulletId = HttpService:GenerateGUID()
+
+	thisEasyBulletSettings.BulletData.BulletId = bulletId
 
 	-- Server; only used for non player bullets.
 	if RunService:IsServer() then
 		for _, v in ipairs(Players:GetPlayers()) do
 			local thisPing = v:GetNetworkPing()
-			self.FiredRemote:FireClient(v, nil, barrelPosition, bulletVelocity, thisPing, easyBulletSettings)
+			self.FiredRemote:FireClient(v, nil, barrelPosition, bulletVelocity, thisPing, thisEasyBulletSettings)
 		end
 
-		self:_fireBullet(nil, barrelPosition, bulletVelocity, 0, easyBulletSettings)
+		self:_fireBullet(nil, barrelPosition, bulletVelocity, 0, thisEasyBulletSettings)
 	
 	-- Client
 	elseif RunService:IsClient() then
@@ -130,9 +148,9 @@ function EasyBullet:FireBullet(barrelPosition: Vector3, bulletVelocity: Vector3,
 			return
 		end
 
-		self.FiredRemote:FireServer(barrelPosition, bulletVelocity, easyBulletSettings)
+		self.FiredRemote:FireServer(barrelPosition, bulletVelocity, thisEasyBulletSettings)
 
-		self:_fireBullet(Players.LocalPlayer, barrelPosition, bulletVelocity, 0, easyBulletSettings)
+		self:_fireBullet(Players.LocalPlayer, barrelPosition, bulletVelocity, 0, thisEasyBulletSettings)
 	end
 end
 
@@ -148,18 +166,42 @@ function EasyBullet:BindShouldFire(callback: ShouldFireCallback)
 	self.ShouldFireCallback = callback
 end
 
-function EasyBullet:_destroyBullet(bullet: Bullet.Bullet)
-	for i, v: Bullet.Bullet in ipairs(self.Bullets) do
-		if v == bullet then
-			table.remove(self.Bullets, i)
-			break
-		end
+function EasyBullet:_destroyBullet(bulletToDestroy: Bullet.Bullet | string)
+	local bulletId: string
+	local bullet: Bullet.Bullet
+
+	if type(bulletToDestroy) == "string" then
+		bulletId = bulletToDestroy
+		bullet = self.Bullets[bulletId]
+	else
+		local tryBulletId = bulletToDestroy.EasyBulletSettings.BulletData.BulletId
+		assert(type(tryBulletId) == "string", "Cannot destroy bullet as EasyBullet did not assign a BulletId for this bullet.")
+		
+		bulletId = tryBulletId
+		bullet = bulletToDestroy
+	end
+
+	self.Bullets[bulletId] = nil
+
+	if self.HitConnections[bulletId] ~= nil then
+		self.HitConnections[bulletId].Disconnect()
+
+		self.HitConnections[bulletId] = nil
+	end
+
+	if self.BelowFallenPartsConnections[bulletId] ~= nil then
+		self.BelowFallenPartsConnections[bulletId].Disconnect()
+
+		self.BelowFallenPartsConnections[bulletId] = nil
 	end
 
 	bullet:Destroy()
 end
 
 function EasyBullet._fireBullet(self: EasyBullet, shootingPlayer: Player?, barrelPos: Vector3, velocity: Vector3, ping: number, easyBulletSettings: Bullet.EasyBulletSettings)
+
+	local bulletId = easyBulletSettings.BulletData.BulletId
+	assert(type(bulletId) == "string", "EasyBullet did not assign a BulletId for this bullet.")
 	
 	-- Let users filter bullets being fired
 	if self.ShouldFireCallback then
@@ -168,60 +210,50 @@ function EasyBullet._fireBullet(self: EasyBullet, shootingPlayer: Player?, barre
 		assert(type(shouldFire) == "boolean", `The callback bound by EasyBullet:BindShouldFire must return a boolean, shouldFireCallback returned: {typeof(shouldFire)}`)
 		
 		if shouldFire == false then
+			
+			assert(self.CanceledRemote ~= nil, "self.CanceledRemote does not reference ReplicatedStorage.EasyBulletCanceled")
+
+			if RunService:IsServer() then
+				self.CanceledRemote:FireAllClients(bulletId)
+			elseif RunService:IsClient() then
+				self.CanceledRemote:FireServer(bulletId)
+			end
+
 			return
 		end
 	end
 
 	local bullet = Bullet.new(shootingPlayer, barrelPos, velocity, easyBulletSettings)
-		
-		local hitConnection, belowFallenParts
 
-		hitConnection = bullet.BulletHit:Connect(function(rayResult: RaycastResult, hitHumanoid: Humanoid | boolean)
-			self.BulletHit:Fire(shootingPlayer, rayResult, easyBulletSettings.BulletData)
+	self.HitConnections[bulletId] = bullet.BulletHit:Connect(function(rayResult: RaycastResult, hitHumanoid: Humanoid | boolean)
+		self.BulletHit:Fire(shootingPlayer, rayResult, easyBulletSettings.BulletData)
 
-			if type(hitHumanoid) ~= "boolean" then
-				self.BulletHitHumanoid:Fire(shootingPlayer, rayResult, hitHumanoid, easyBulletSettings.BulletData)
-			end
+		if type(hitHumanoid) ~= "boolean" then
+			self.BulletHitHumanoid:Fire(shootingPlayer, rayResult, hitHumanoid, easyBulletSettings.BulletData)
+		end
 
-			hitConnection:Disconnect()
-			belowFallenParts:Disconnect()
+		self:_destroyBullet(bullet)
+	end)
 
-			self:_destroyBullet(bullet)
-		end)
+	self.BelowFallenPartsConnections[bulletId] = bullet.BelowFallenParts:Connect(function()
+		self:_destroyBullet(bullet)
+	end)
 
-		belowFallenParts = bullet.BelowFallenParts:Connect(function()
-			hitConnection:Disconnect()
-			belowFallenParts:Disconnect()
+	bullet:Start(ping)
 
-			self:_destroyBullet(bullet)
-		end)
-
-		bullet:Start(ping)
-
-		table.insert(self.Bullets, bullet)
+	self.Bullets[bulletId] = bullet
 end
 
 function EasyBullet:_bindEvents()
 	-- Server
 	if RunService:IsServer() then
-		local firedRemote = ReplicatedStorage:FindFirstChild("EasyBulletFired") :: RemoteEvent
 
-		if not firedRemote then
-			self.FiredRemote = Instance.new("RemoteEvent")
-
-			if self.FiredRemote then
-				self.FiredRemote.Name = "EasyBulletFired"
-				self.FiredRemote.Parent = ReplicatedStorage
-			end
-		else
-			self.FiredRemote = firedRemote
-		end
-
-		if not self.FiredRemote then
-			return
-		end
+		-- Look for existing EasyBulletFired RemoteEvent. Create one if it does not exist.
+		self.FiredRemote = self:_findOrCreateRemote("EasyBulletFired")
+		assert(self.FiredRemote ~= nil, "self.FiredRemote cannot be nil.")
 
 		self.FiredRemote.OnServerEvent:Connect(function(player: Player, barrelPos: Vector3, velocity: Vector3, easyBulletSettings: Bullet.EasyBulletSettings)
+			-- Sanity check params
 			if typeof(barrelPos) ~= "Vector3" then
 				warn(`{player.Name} passed a malformed barrelPosition type to EasyBulletFired RemoteEvent\nExpected: Vector3, got: {typeof(barrelPos)}`)
 				return
@@ -232,8 +264,10 @@ function EasyBullet:_bindEvents()
 				return
 			end
 
+			-- Use shooter's ping to account for network desync.
 			local ping = player:GetNetworkPing()
 
+			-- Replicate shot to all other clients
 			for _, v in ipairs(Players:GetPlayers()) do
 				if v == player then continue end
 				
@@ -242,31 +276,73 @@ function EasyBullet:_bindEvents()
 				self.FiredRemote:FireClient(v, player, barrelPos, velocity, ping + thisPing, easyBulletSettings)
 			end
 
+			-- Start handling the shot on the server
 			self:_fireBullet(player, barrelPos, velocity, ping, easyBulletSettings)
 		end)
 
+		-- Look for existing EasyBulletCanceled RemoteEvent. Create one if it does not exist.
+		self.CanceledRemote = self:_findOrCreateRemote("EasyBulletCanceled")
+		assert(self.CanceledRemote ~= nil, "self.CanceledRemote cannot be nil.")
+
+		-- Handle the CanceledRemote
+		self.CanceledRemote.OnServerEvent:Connect(function(cancelingPlayer: Player, bulletId: string)
+			local bullet = self.Bullets[bulletId]
+
+			if not bullet then
+				warn(`No Bullet with a BulletId of {bulletId} was found`)
+				return
+			end
+
+			if not bullet.Shooter then
+				warn(`{cancelingPlayer.Name} cannot cancel a bullet owned by the server. BulletId: {bulletId}`)
+				return
+			end
+
+			if bullet.Shooter and bullet.Shooter ~= cancelingPlayer then
+				warn(`{cancelingPlayer.Name} cannot cancel a bullet owned by {bullet.Shooter.Name}. BulletId: {bulletId}`)
+				return
+			end
+
+			self:_destroyBullet(bulletId)
+		end)
+
+
 	-- Client
 	elseif RunService:IsClient() then
+		-- Make references to our remotes
 		self.FiredRemote = ReplicatedStorage:WaitForChild("EasyBulletFired") :: RemoteEvent
+		self.CanceledRemote = ReplicatedStorage:WaitForChild(("EasyBulletCanceled")) :: RemoteEvent
 
 		if not self.FiredRemote then
 			warn("No RemoteEvent named 'EasyBulletFired' found as a child of ReplicatedStorage")
 			return
 		end
-		
 
+		if not self.CanceledRemote then
+			warn("No RemoteEvent named 'EasyBulletCanceled' found as a child of ReplicatedStorage")
+			return
+		end
+		
+		-- Handle the FiredRemote
 		self.FiredRemote.OnClientEvent:Connect(function(shootingPlayer: Player, barrelPos: Vector3, velocity: Vector3, accumulatedPing: number, easyBulletSettings: Bullet.EasyBulletSettings)
+			-- The server shouldn't ever replicate back a shot this client fired, but check that just to be safe.
 			if shootingPlayer == Players.LocalPlayer then
 				return
 			end
 			
 			self:_fireBullet(shootingPlayer, barrelPos, velocity, accumulatedPing, easyBulletSettings)
 		end)
+
+		-- Handle the CanceledRemote
+		self.CanceledRemote.OnClientEvent:Connect(function(bulletId: string)
+			self:_destroyBullet(bulletId)
+		end)
+
 	end
 
 	-- Both
 	RunService.Heartbeat:Connect(function()
-		for _, bullet: Bullet.Bullet in ipairs(self.Bullets) do
+		for _, bullet: Bullet.Bullet in pairs(self.Bullets) do
 			local lastPosition, currentPosition = bullet:Update(self.CustomCastCallback)
 
 			-- Update returns nil when bullet drops below workspace.FallenPartsDestroyHeight
@@ -275,6 +351,22 @@ function EasyBullet:_bindEvents()
 			end
 		end
 	end)
+end
+
+function EasyBullet:_findOrCreateRemote(remoteName: string): RemoteEvent
+	local foundRemote = ReplicatedStorage:FindFirstChild(remoteName)
+
+	if foundRemote == nil then
+		foundRemote = Instance.new("RemoteEvent")
+		foundRemote.Name = remoteName
+		foundRemote.Parent = ReplicatedStorage
+
+		return foundRemote
+	elseif foundRemote:IsA("RemoteEvent") then
+		return foundRemote
+	else
+		error(`Instance named {remoteName} is of type {foundRemote.ClassName}, not RemoteEvent`)
+	end
 end
 
 return EasyBullet

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zachcurtis/easybullet"
-version = "0.3.0"
+version = "0.3.1"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 


### PR DESCRIPTION
indexes existing Bullet objects by a UUID so they can be canceled by the ShouldFireCallback without impacting replication latency.